### PR TITLE
Fixed issue with group names created by inventory_import playbook

### DIFF
--- a/tools/inventory_import/inventory_import.yml
+++ b/tools/inventory_import/inventory_import.yml
@@ -11,8 +11,8 @@
     organization: "Default" #Default org setup by Tower Install
     inventory_name: "Ansible Lightbulb Lab" #Follows inventory_name in docs for Lightbulb
     group_name:
-      - "Web"
-      - "Control"
+      - "web"
+      - "control"
 
   tasks:
   - name: Install pip and ansible-tower-cli


### PR DESCRIPTION
Adjusted inventory group names created by playbook to match existing names elsewhere in project playbooks etc.