### PR TITLE
Spelling corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Lightbulb began life as the content that supported Ansible's training program be
 
 This content is now taking on a new life as a multi-purpose toolkit for effectively demonstrating Ansible's capabilities or providing informal workshop training in various forms -- instructor-led, hands-on or self-paced.
 
-Over time lightbulb will be expanded to include advanced and developer topics in addition to expanding beyond linux server automation and into Windows and network automation.
+Over time Lightbulb will be expanded to include advanced and developer topics in addition to expanding beyond linux server automation and into Windows and network automation.
 
-To support these objectives, the project provides a lab provisioner tool for creating an environment to present and work with lightbulb content.
+To support these objectives, the project provides a lab provisioner tool for creating an environment to present and work with Lightbulb content.
 
 ### What's Provided
 
@@ -22,7 +22,7 @@ The Ansible Lightbulb project has been designed to be used as a toolkit and best
 
 #### Examples
 
-The content in `examples/` is the heart of what lightbulb has to offer. They are complete Ansible playbooks that demonstrate the most fundamental features and most common use patterns.
+The content in `examples/` is the heart of what Lightbulb has to offer. They are complete Ansible playbooks that demonstrate the most fundamental features and most common use patterns.
 
 These examples are an excellent educational reference for communicating how Ansible works in a clear, focused and consistent manner using recommended best practices.
 
@@ -42,17 +42,17 @@ The content of `decks/` are collection of presentation decks using the [reveal.j
 
 Lightbulb provides a lab provisioner utility for creating a personal lab environment for each student. Currently only Amazon Web Services (AWS) is supported in us-east-1 and us-west-1 with the foundation to support other regions in place.
 
-**Coming Soon.** Vagrant support for self-paced learning is planned. Legacy support from the previous generation of lightbulb remains, but is in need of an overhaul.
+**Coming Soon.** Vagrant support for self-paced learning is planned. Legacy support from the previous generation of Lightbulb remains, but is in need of an overhaul.
 
 #### Facilitator Guide
 
 `facilitator/` includes documentation on recommended ways Lightbulb content can be assembled and used for a wide range of purposes and scenarios.
 
-If you are planning on using lightbulb for some sort of informal training on automating with Ansible [this documentation](facilitator/README.md) should be your next stop.
+If you are planning on using Lightbulb for some sort of informal training on automating with Ansible [this documentation](facilitator/README.md) should be your next stop.
 
 ### Requirements
 
-True to its philosophy and The Ansible Way, Lightbulb has been developed so that using lightbulb is as simple and low-overhead as possible. Requirements depend on the format and delivery of the lightbulb content.
+True to its philosophy and The Ansible Way, Lightbulb has been developed so that using Lightbulb is as simple and low-overhead as possible. Requirements depend on the format and delivery of the Lightbulb content.
 
 * Modern HTML5 Standard Compliant Web Browser
 * A recent stable version of Python 2.7 and the latest stable version of the boto libraries.
@@ -64,7 +64,7 @@ True to its philosophy and The Ansible Way, Lightbulb has been developed so that
 
 For hands-on or self-paced training, students should have working knowledge of using SSH and command line shell (BASH). The ability to SSH from their personal laptop to a lab environment hosted in a public cloud can also be required based on the format and presentation of the context.
 
-For demos and instrcutor-led exercises, conceptual understanding of linux system admin, DevOps and distributed application architecture is all that is required.
+For demos and instructor-led exercises, conceptual understanding of linux system admin, DevOps and distributed application architecture is all that is required.
 
 ### Reference
 

--- a/decks/ansible-essentials.html
+++ b/decks/ansible-essentials.html
@@ -58,7 +58,7 @@
             <p>This deck is designed to provide students with direct introductory instruction and guidance to beginning to automate with Ansible. It is the starting point for students intent on becoming more proficient with Ansible through other Lightbulb modules and their own usage.</p>
             <p>This deck supports lecture and hands-on forms of presenting this material. </p>
             <p>Allow 2 hours to deliver the lecture-based form and 4 hours for stopping to do the workshop assignments. To access the additional slides for delivering the workshops, navigate down when available. </p>
-            <p>See the <a href="../facilitator/README.md">Ansible Lighttbulb facilitator&rsquo;s guide</a> for more details on using this deck and it&rsquo;s associated material.</p>
+            <p>See the <a href="../facilitator/README.md">Ansible Lightbulb facilitator&rsquo;s guide</a> for more details on using this deck and it&rsquo;s associated material.</p>
           </aside>
         </section>
         <section>
@@ -82,7 +82,7 @@
             <aside class="notes">
               <p>Ansible has a number of qualities that make it the most rapidly growing automation platform in the world. </p>
               <p><strong>Ansible is simple.</strong> Playbooks are human and machine readable, no special coding skills required &ndash; and even people in your IT organization that don’t know Ansible can read an Ansible playbook and understand what’s happening.</p>
-              <p>This simplicity also means that it&rsquo;s easy to install and get startedto do real work with it quickly &ndash; usually in just minutes. </p>
+              <p>This simplicity also means that it&rsquo;s easy to install and get started to do real work with it quickly &ndash; usually in just minutes. </p>
               <p>Ansible also works like you think &ndash; tasks are always executed in order. All together, the simplicity ensures that you can get started quickly.</p>
               <p><strong>Ansible is powerful.</strong> Simplicity is great, but to be really useful, you also need the powerful features that ensure you can model even the most complex of IT workflows.</p>
               <p>Ansible is complete automation, able to deploy apps, manage orchestration, and configure the infrastructure, networks, operating systems, and services that you’re already using today. </p>
@@ -187,7 +187,7 @@
           <img src="images/ansible-automation-diagram.svg"/>
           <aside class="notes">
             <p>Ansible is complete automation. It&apos;s not just configuration management, It&apos;s provisioning infrastructure, deploying applications, and orchestrating actions against all layers of IT infrastructure in a single tool.</p>
-            <p>Ansibles capabilities allow you to orchestrate the entire application and environment lifecycle, regardless of where It&apos;s deployed.</p>
+            <p>Ansible's capabilities allow you to orchestrate the entire application and environment lifecycle, regardless of where It&apos;s deployed.</p>
           </aside>
         </section>
         <section>
@@ -196,7 +196,7 @@
           <aside class="notes">
             <p>What can you do with Ansible? Nearly anything. Ansible is the Swiss Army knife of DevOps, capable of handling many powerful automation tasks with the flexibility to adapt to many environments and workflows.</p>
             <p>Many folks like to categorize Ansible as a configuration manager, and although yes, Ansible can do that, it&quot;s just the tip of the iceberg. When you couple configuration management with orchestration, you can start to model complicated multi-tier deployments with ease.</p>
-            <p>With Ansible, once soneone on your team automates something, everyone on the team now knows how to do it.</p>
+            <p>With Ansible, once someone on your team automates something, everyone on the team now knows how to do it.</p>
           </aside>
         </section>
         <section>
@@ -216,22 +216,22 @@ $ sudo apt-get install ansible
           </code></pre>
           <aside class="notes">
             <p>As open source, Ansible is freely-available thru numerous means and can be installed in minutes with only a few requirements that most system already have. The installation methods listed here are the most commonly used.</p>
-            <p>Currently Ansible can be run from any machine with Python 2.6 or 2.7 installed. Python 3 support is in tech preview as of version 2.2. Windows isn’t supported for the control machine.</p>
+            <p>Currently Ansible can be run from any machine with Python 2.6 or 2.7 installed. Python 3 support is in tech preview as of version 2.2. Windows isn't supported for the control machine.</p>
             <p>The requirements of nodes being managed by Ansible vary based on the type and access used to work with them. Ansible needs a way to communicate, which is normally ssh or winrm though other means such as RESTful APIs and specialized connection types may be necessary. Linux servers will need Python 2.6 or later. Windows serves need PowerShell 3.</p>
-            <p>For more details see <a href="http://docs.ansible.com/ansible/intro_installation.html">the Installation page</a> in the Ansible documenation.
+            <p>For more details see <a href="http://docs.ansible.com/ansible/intro_installation.html">the Installation page</a> in the Ansible documentation.
           </aside>
         </section>
         <section>
           <section data-state="title alt">
           <h1>Demo Time: <br/>Installing Ansible</h1>
           <aside class="notes">
-            <p>To demonstrate how easy it is to install Ansible, open an SSH session to your control host and install ansible using one of the methods in the previous slide. Once complete do a <code>$ ansible --version</code>.</p>
+            <p>To demonstrate how easy it is to install Ansible, open an SSH session to your control host and install Ansible using one of the methods in the previous slide. Once complete do a <code>$ ansible --version</code>.</p>
           </aside>
           </section>
           <section data-state="title alt">
             <h1>Workshop: <br/>Installing Ansible</h1>
             <aside class="notes">
-              <p>This brief exercise demonstrates how easy it can be to install and configure ansible and begin automating.</p>
+              <p>This brief exercise demonstrates how easy it can be to install and configure Ansible and begin automating.</p>
               <p>See <code>workshops/ansible_install</code> in the Ansible Lightbulb repo for this workshop&apos;s assignment. It's solution and addition details can be found in <code>facilitator/solutions/ansible_install.md</code>.</p>
             </aside>
           </section>
@@ -248,7 +248,7 @@ $ sudo apt-get install ansible
           <img src="images/how-ansible-works-diagram-02.svg" />
           <aside class="notes">
             <p>Playbooks are written in YAML and are used to invoke Ansible modules to perform tasks that are executed sequentially i.e top to bottom. They can describe a policy you want your remote systems to enforce, or a set of steps in a general IT workflow. Playbooks are like an instruction manual and describe the state of environment.</p>
-            <p>For more details see <a href="http://docs.ansible.com/ansible/playbooks.html">the Playbook page</a> in the Ansible documenation.</p>
+            <p>For more details see <a href="http://docs.ansible.com/ansible/playbooks.html">the Playbook page</a> in the Ansible documentation.</p>
           </aside>
         </section>
         <section>
@@ -281,7 +281,7 @@ $ sudo apt-get install ansible
           <img src="images/how-ansible-works-diagram-05.svg" />
           <aside class="notes">
             <p>Your inventory of hosts are your raw material. They are a list of nodes and associated meta data that Ansible can automate.</p>
-            <p>Inventory lists can be built and stored several different ways, including static files, or can be dynamically-generated from an an external source.</p>
+            <p>Inventory lists can be built and stored several different ways, including static files, or can be dynamically-generated from an external source.</p>
             <p>You can also specify variables as part of an inventory list. For instance, set a particular host key that’s needed to log into that system remotely.  Inventories are ultimately lists of things you want to automate across.</p>
             <p>Here in this slide was see an example of a simple static inventory list of three hosts (webserver1, webserver2 and dbserver1) in two groups (web and db).</p>
             <p>For more details see the <a href="http://docs.ansible.com/ansible/intro_inventory.html">Inventory</a> page in the Ansible documentation.</p>
@@ -326,7 +326,7 @@ $ sudo apt-get install ansible
           </div>
           <aside class="notes">
             <p>If playbooks are the instruction manual for setting up and managing your infrastructure, Ansible modules are the tools in your toolkit.</p>
-            <p>We&rsquo;ve already discussed, Ansible modules. They are the &ldquo;batteries&rdquo; and the &ldquo;tools in a users toolkit.&rdquo;</p>
+            <p>We've already discussed, Ansible modules. They are the &ldquo;batteries&rdquo; and the &ldquo;tools in a users toolkit.&rdquo;</p>
             <p>While there are hundreds of modules at your disposal out-of-the-box these are the most common ones.</p>
             <p>Playbook tasks and how they relate to modules will be covered ahead. Tasks are the application of a module to perform a specific unit of work.</p>
           </aside>
@@ -374,7 +374,7 @@ Options (= is mandatory):
         </aside>
         <section>
           <h2>Modules: Run Commands</h2>
-          <p>If Ansible doesn’t have a module that suits your needs there are the “run command” modules:</p><br>
+          <p>If Ansible doesn't have a module that suits your needs there are the “run command” modules:</p><br>
           <ul>
             <li><b>command</b>: Takes the command and executes it on the host. The most secure and predictable.</li>
             <li><b>shell</b>: Executes through a shell like <code>/bin/sh</code> so you can use pipes etc. Be careful.</li>
@@ -383,7 +383,7 @@ Options (= is mandatory):
           </ul>
           <p><br><b>NOTE:</b> Unlike standard modules, run commands have no concept of desired state and should only be used as a last resort.</p>
           <aside class="notes">
-            <p>&quot;Run commands&quot; are what we collectively call these modules that enable users to do commandline operations in different ways. They’re a great catch all mechanism for getting things done, but they should be used sparingly and as a last resort. The reasons are many and varied.</p>
+            <p>&quot;Run commands&quot; are what we collectively call these modules that enable users to do command-line operations in different ways. They’re a great catch all mechanism for getting things done, but they should be used sparingly and as a last resort. The reasons are many and varied.</p>
             <p>The overuse of run commands is common amongst those just becoming familiar with Ansible for automating their work. They use <code>shell</code> to fire off a bash command they already know without stopping to look at the Ansible docs. That works well enough initially, but it undermines the value of automating with Ansible and sets things up for problems down the road. <b>As a best practice, always check the hundreds of Ansible shipping modules for what you need and use those first and run commands as a last resort.</b></p>
             <p><b>NOTE:</b> <code>shell</code> allows for IO redirection such as pipes. This is why It&apos;s best practice to use <code>command</code> unless they need to pipe something. It also best practice to <strong>never</strong> pass user input or variables thru a run command.</p>
           </aside>
@@ -400,8 +400,8 @@ Options (= is mandatory):
           <aside class="notes">
             <p>We've already discussed inventory in our review of Ansible's key components.</p>
             <p>Inventory consists of hosts, groups, inventory specific data. Inventory can either be static or dynamic.</p>
-            <p>Inventory is a collection of the hosts (nodes) with associated metadata and groupings that Ansible can connect and manage. An inventory source can be static files or dynamically retreived from an external system.</p>
-            <p>You can specify a different inventory file using the <code>-i &lt;path&gt;</code> option on the commandline or your Ansible configuration file.</p>
+            <p>Inventory is a collection of the hosts (nodes) with associated metadata and groupings that Ansible can connect and manage. An inventory source can be static files or dynamically retrieved from an external system.</p>
+            <p>You can specify a different inventory file using the <code>-i &lt;path&gt;</code> option on the command-line or your Ansible configuration file.</p>
           </aside>
         </section>
         <section>
@@ -415,8 +415,8 @@ Options (= is mandatory):
 host.example.com
           </code></pre>
           <aside class="notes">
-            <p>Static inventory is the easiest source to get started with. This example shows a static inventory source in It&rsquo;s simplist form &ndash; a single file with a list of IP addresses or hostnames.</p>
-            <p><strong>NOTE:</strong> Ansible infers a localhost is present even if it is not explictly listed. This is why you can actually run Ansible without a inventory source. Ansible will only be able to operate on the localhost where it is being run.</p>
+            <p>Static inventory is the easiest source to get started with. This example shows a static inventory source in It&rsquo;s simplest form &ndash; a single file with a list of IP addresses or hostnames.</p>
+            <p><strong>NOTE:</strong> Ansible infers a localhost is present even if it is not explicitly listed. This is why you can actually run Ansible without a inventory source. Ansible will only be able to operate on the localhost where it is being run.</p>
           </aside>
         </section>
         <section>
@@ -437,14 +437,14 @@ ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key
           </code></pre>
           <aside class="notes">
             <p>The example shown here is a more practical and common example of a static inventory file.</p>
-            <p>Static inventory files are expresed in INI format. The headings in brackets are group names, which are used in classifying systems and deciding what systems you are controlling at what times and for what purpose. Hosts can belong to multiple groups and groups can be members of other groups. (The latter is not shown here.)</p>
+            <p>Static inventory files are expressed in INI format. The headings in brackets are group names, which are used in classifying systems and deciding what systems you are controlling at what times and for what purpose. Hosts can belong to multiple groups and groups can be members of other groups. (The latter is not shown here.)</p>
             <p>NOTE: This example contains variables, a topic we haven't touched on just yet. We'll go into them on the next slide.</p>
             <p>Other noteworthy attributes in our example:</p>
             <ul>
               <li><code>ansible_host</code> is an example of a host variable.</li>
               <li>Hosts can be assigned arbitrary human-meaningful names or aliases such as "control" and "haproxy". Ansible will instead use the value of <code>ansible_host</code> (one of several <a href="http://docs.ansible.com/ansible/playbooks_variables.html#magic-variables-and-how-to-access-information-about-other-hosts">&quot;magic&quot; inventory variables</a>) as the network address to connect.</li>
               <li>Static inventory files can support character ranges such as &quot;node-[1:3]&quot;</li>
-              <li>Like localhost, Ansible infers an &quot;all&quot; group is present. As its name implies, all inventory hosts are memebers of this group.</li>
+              <li>Like localhost, Ansible infers an &quot;all&quot; group is present. As its name implies, all inventory hosts are members of this group.</li>
               <li>The heading &quot;all:vars&quot; is an example of group variable assignment using two more &quot;magic&quot; variables, <code>ansible_ssh_private_key_file</code> and <code>ansible_user</code>.</li>
             </ul>
             <p>This example just covers the basics. There's a lot more to inventory that is not covered here. See the <a href="http://docs.ansible.com/ansible/intro_inventory.html">Ansible inventory documentation</a> for more details.</p>
@@ -468,10 +468,10 @@ ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key
               <li><b>-b, --become</b><br/>Run ad-hoc command with elevated rights such as sudo, the default method</li>
               <li><b>-e EXTRA_VARS, --extra-vars=EXTRA_VARS</b><br/>Set additional variables as key=value or YAML/JSON</li>
               <li><b>--version</b><br/>Display the version of Ansible</li>
-              <li><b>--help</b><br/>Display the MAN page for the ansible tool</li>
+              <li><b>--help</b><br/>Display the MAN page for the Ansible tool</li>
             </ul>
             <aside class="notes">
-              <p>This slide shows essential commanline options for running ad-hoc commands that will be useful in our upcoming workshop assignment.</p>
+              <p>This slide shows essential command-line options for running ad-hoc commands that will be useful in our upcoming workshop assignment.</p>
             </aside>
           </section>
         </section>
@@ -518,7 +518,7 @@ localhost | success >> {
           </code></pre>
           <aside class="notes">
             <p>The second ad-hoc command example from the prior slide provides the following JSON output of a localhost facts run.</p>
-            <p>Facts are bits of information derived from examining a host systems that are stored as variables for later use. An example of this might be the ip address of the host, or what operating system it is running. The facts Ansible will discover about a host is extensive. What's shown here is just a small sample. Run <code>ansible localhost -m setup</code> for a more complete represenation.</p>
+            <p>Facts are bits of information derived from examining a host systems that are stored as variables for later use. An example of this might be the IP address of the host, or what operating system it is running. The facts Ansible will discover about a host is extensive. What's shown here is just a small sample. Run <code>ansible localhost -m setup</code> for a more complete representation.</p>
             <p>Ansible collects facts using the <code>setup</code> module. By default, Ansible will run the <code>setup</code> module before any other tasks are executed in a playbook. These facts can be referenced by subsequent automation tasks on a per host-basis during the playbook run.</p>
           </aside>
         </section>
@@ -590,7 +590,7 @@ $ ansible web -m command -a &quot;uptime&quot;
           </div>
           <aside class="notes">
             <p>If variables of the same name are defined in multiple sources, they get overwritten in a certain and specific order. This is why this variable precedence is important to understand.</p>
-            <p>There are 16 levels of variable precedence as of Ansible 2.x. The <code>extra_vars</code> (passed thru the commandline) always take precedence vs. role defaults which will always get overridden by any other source. The previous inventory example defines vars at 13 and 14 (higlighted in the list) in the variable precedence chain.</p>
+            <p>There are 16 levels of variable precedence as of Ansible 2.x. The <code>extra_vars</code> (passed thru the command-line) always take precedence vs. role defaults which will always get overridden by any other source. The previous inventory example defines vars at 13 and 14 (highlighted in the list) in the variable precedence chain.</p>
             <p>It&apos;s a good idea to limit the different sources where a specific variable is being set. While Ansible's variable precedence handling is comprehensive and well-defined, it can laborious to keep the resolution of multiple sources straight.</p>
             <p>NOTE: The inventory variables sources showed in the static inventory example a couple of slides back are in bold type.</p>
           </aside>
@@ -607,7 +607,7 @@ $ ansible web -m command -a &quot;uptime&quot;
             <li><b>git</b>: Clone a source code repository</li>
           </ul>
           <aside class="notes">
-            <p>We&apos;ve already reviewed modules, the batteries and tools Ansible provides. Tasks are the specific application of a module to perform a unit of automation.</p>
+            <p>We've already reviewed modules, the batteries and tools Ansible provides. Tasks are the specific application of a module to perform a unit of automation.</p>
             <p>Here we see a list of examples of common modules being applied to do something.</p>
           <aside>
         </section>
@@ -672,7 +672,7 @@ tasks:
     state: restarted
           </code></pre>
           <aside class="notes">
-            <p>Here is our previous example with a few slight modifications that have bene highlighted.</p>
+            <p>Here is our previous example with a few slight modifications that have been highlighted.</p>
             <p>In this version of our example, we add a <code>notify</code> keyword to the first task to trigger a handler task if it returns &quot;changed&quot; as being true. The third tasks now is under a &quot;handlers&quot; section that signifies that the handler task will run on notification at the end of the play of change occurs during the first task.</p>
           </aside>
         </section>
@@ -681,7 +681,7 @@ tasks:
           <p>Plays are ordered sets of tasks to execute against host selections from your inventory. A playbook is a file containing one or more plays.</p>
           <aside class="notes">
             <p>Playbooks are text files that contain one or more plays that are expressed in YAML. A play defines target hosts and a task list that are executed sequentially (i.e top to bottom) to achieve a certain state on those hosts.</p>
-            <p>For more details see <a href="http://docs.ansible.com/ansible/playbooks.html">the Playbook page</a> in the Ansible documenation.</p>
+            <p>For more details see <a href="http://docs.ansible.com/ansible/playbooks.html">the Playbook page</a> in the Ansible documentation.</p>
           </aside>
         </section>
         <section>
@@ -774,9 +774,9 @@ tasks:
       state: started
           </code></pre>
           <aside class="notes">
-            <p>The Ansible play host selector defines which nodes in the inventory the automation is targetting.</p>
-            <p>In this example, a single group of &quot;web&quot; is being targetted. Ansible supports targetting intersections, unions and filters of multiple groups or hosts though.</p>
-            <p>For more details see <a href="http://docs.ansible.com/ansible/intro_patterns.html">the host selector Patterns page</a> in the Ansible documenation.</p>
+            <p>The Ansible play host selector defines which nodes in the inventory the automation is targeting.</p>
+            <p>In this example, a single group of &quot;web&quot; is being targeted. Ansible supports targeting intersections, unions and filters of multiple groups or hosts though.</p>
+            <p>For more details see <a href="http://docs.ansible.com/ansible/intro_patterns.html">the host selector Patterns page</a> in the Ansible documentation.</p>
           </aside>
         </section>
         <section>
@@ -807,7 +807,7 @@ tasks:
           </code></pre>
           <aside class="notes">
             <p>Ansible allows you to &quot;become&quot; another user or with elevated rights to execute a task or an entire play (shown above). This is done using existing privilege escalation tools, which you probably already use or have configured, like sudo (the default), su, pfexec, doas, pbrun, dzdo, ksu and others.</p>
-            <p>For more details see <a href="http://docs.ansible.com/ansible/become.html">the Privilege Escalation page</a> in the Ansible documenation.</p>
+            <p>For more details see <a href="http://docs.ansible.com/ansible/become.html">the Privilege Escalation page</a> in the Ansible documentation.</p>
           </aside>
         </section>
         <section>
@@ -882,7 +882,7 @@ tasks:
           <section data-state="title alt">
             <h1>Workshop: <br/>Your First Playbook</h1>
             <aside class="notes">
-              <p>This assignment provides a quick introduction to playbook structure to give them a feel for how Ansible works, but in pratice is too simplistic to be useful.</p>
+              <p>This assignment provides a quick introduction to playbook structure to give them a feel for how Ansible works, but in practice is too simplistic to be useful.</p>
               <p>See <code>workshops/simple_playbook</code> in the Ansible Lightbulb repo.</p>
               <p>Note: If your time is limited, this is a workshop you can skip. We'll cover this and more topics in the next workshop.</p>
             </aside>
@@ -900,7 +900,7 @@ tasks:
               <li>Blocks</li>
             </ul>
             <aside class="notes">
-              <p>We only have covered the most essential capabiltites of what can be done with a playbook so far.</p>
+              <p>We only have covered the most essential capabilities of what can be done with a playbook so far.</p>
               <p>Here we list a few more though this is still far from all there is. There&apos;s many other powerful playbook features for handling less common though vital automation workflows. No need to learn everything at once. You can start small and pick up more features over time as you need them.</p>
             </aside>
           </section>
@@ -951,7 +951,7 @@ tasks:
             <aside class="notes">
               <p>Conditionals are another instance of Jinja2 in action within Ansible plays themselves. In the provided example &quot;ansible_os_family&quot; is a fact variable Ansible will set.</p>
               <p>There are other forms of conditional clauses, but <code>when</code> is usually all that is needed.</p>
-              <p>NOTE: Conditional clauses are consdered to be raw Jinja2 expression without double curly braces.</p>
+              <p>NOTE: Conditional clauses are considered to be raw Jinja2 expression without double curly braces.</p>
             </aside>
           </section>
           <section>
@@ -1005,7 +1005,7 @@ tasks:
           <section data-state="title alt">
             <h1>Demo Time: <br/>A More Practical Playbook</h1>
             <aside class="notes">
-              <p>The simple playbook we examined gave us a sense of the structure of a playbook and how they work, but in reality was too simlistic to be practical. Here we look at a basic playbook that it more complete to what users will commonly do with Ansible.</p>
+              <p>The simple playbook we examined gave us a sense of the structure of a playbook and how they work, but in reality was too simplistic to be practical. Here we look at a basic playbook that it more complete to what users will commonly do with Ansible.</p>
               <p>Walk thru the site.yml playbook in <code>examples/apache-basic-playbook</code> and note the added logic and its function. Then, run the playbook on the control host.</p>
               <p>Don't forget to reverse what this playbook does before continuing to not interfere with later demos and workshops.</p>
             </aside>
@@ -1078,7 +1078,7 @@ roles/
           <p>Ansible Galaxy is a hub for finding, reusing and sharing Ansible content.</p>
           <p>Jump-start your automation project with content contributed and reviewed by the Ansible community.</p>
           <aside class="notes speaker">
-            <p>Ansible Galaxy refers to the Galaxy website, a hub for finding, downloading, and sharing community developed roles. Downloading roles from Galaxy is a great way to jumpstart your automation projects.
+            <p>Ansible Galaxy refers to the Galaxy website, a hub for finding, downloading, and sharing community developed roles. Downloading roles from Galaxy is a great way to jump-start your automation projects.
             <p>Galaxy also refers to a command line tool, <code>ansible-galaxy</code>, for installing, creating and managing roles from the Galaxy website or directly from a git based SCM. You can also use it to create a new role, remove roles, or perform tasks on the Galaxy website.</p>
           </aside>
         </section>
@@ -1093,7 +1093,7 @@ roles/
             <section data-state="title alt">
               <h1>Workshop: <br/>Your First Roles</h1>
               <aside class="notes">
-                <p>Here students are tasked with refactoring their previous work from the Practical Playbook workshop into a role and modifying their playbook accordingly. We intentioinally avoid introducing any new tasks or functionality otherwise. The objective here is to focus students specifically on how roles are structured and develop.</p>
+                <p>Here students are tasked with refactoring their previous work from the Practical Playbook workshop into a role and modifying their playbook accordingly. We intentionally avoid introducing any new tasks or functionality otherwise. The objective here is to focus students specifically on how roles are structured and develop.</p>
                 <p>You should emphasize the value of roles in better organizing playbooks as they grow in sophistication and making Ansible automation more portable and reusable than a basic playbook.</p>
                 <p>See <code>workshops/roles</code> in the Ansible Lightbulb repo.</p>
               </aside>

--- a/decks/intro-to-ansible-tower.html
+++ b/decks/intro-to-ansible-tower.html
@@ -53,10 +53,10 @@
             <li>Key Features</li>
           </ul>
           <aside class="notes">
-            <p>This deck was designed to provide students with a general overview of how ansible core knowledge can be transitioned into Ansible Tower.</p>
+            <p>This deck was designed to provide students with a general overview of how Ansible core knowledge can be transitioned into Ansible Tower.</p>
             <p>This deck supports lecture and hands-on forms of presenting this material. </p>
             <p>Allow 2 hours to deliver the lecture-based form and 4 hours for stopping to do the workshop assignments. To access the additional slides for delivering the workshops, navigate down when available. </p>
-            <p>See the <a href="../facilitator/README.md">Ansible Lighttbulb facilitator&rsquo;s guide</a> for more details on using this deck and it&rsquo;s associated material.</p>
+            <p>See the <a href="../facilitator/README.md">Ansible Lightbulb facilitator&rsquo;s guide</a> for more details on using this deck and it&rsquo;s associated material.</p>
           </aside>
         </section>
         <section>
@@ -68,7 +68,7 @@
               <li>All Ansible automations are <strong>centrally logged</strong>, ensuring <strong>complete auditability and compliance</strong></li>
             </ul>
             <aside class="notes">
-              <p>Red Hat Ansible Tower offers the control around ansible automations in the form of RBAC, Job Scheduling, security abstraction from the user and API integrations with other systems.</p>
+              <p>Red Hat Ansible Tower offers the control around Ansible automations in the form of RBAC, Job Scheduling, security abstraction from the user and API integrations with other systems.</p>
               <p>In Ansible Tower, all Ansible job launches are tracked and logged centrally. What was changed and when it was changed can be viewed, exported to other logging capabilities and controlled within allowances of a user's access based on role.</p>
             </aisde>
         </section>
@@ -125,9 +125,9 @@ $ wget https://bit.ly/ansibletowerbundle
           <section data-state="title alt">
           <h1>Demo Time: <br/>Installing Ansible Tower</h1>
           <aside class="notes">
-            <p>Installing Ansible Tower is simple and quick. Go ahead and open up a terminal and connect to VM with an os of your choice.</p>
+            <p>Installing Ansible Tower is simple and quick. Go ahead and open up a terminal and connect to VM with an OS of your choice.</p>
             <p>Start by downloading the latest bundled tower installer from https://bit.ly/ansibletowerbundle and unpack the tarball once it is done downloading.</p>
-            <p>Now that the package is unzipped, move into the directory and look for the inventory file. Here you will set all the neccesary passwords needed for the install to take place. </p>
+            <p>Now that the package is unzipped, move into the directory and look for the inventory file. Here you will set all the necessary passwords needed for the install to take place. </p>
             <p>You will need to set:</p>
             <ul>
               <li>admin_password</li>
@@ -185,7 +185,7 @@ $ wget https://bit.ly/ansibletowerbundle
               <p>A system administrator (also known as Superuser) has admin, read, and write privileges over the entire Ansible Tower installation. A System Administrator is typically responsible for managing all aspects of Ansible Tower and delegating responsibilities for day-to-day work to various Users.
               <p>An organization is is a logical collection of Users, Teams, Projects, and Inventories, and is the highest level in the Ansible Tower object hierarchy.</p>
               <p>A Team is a subdivision of an organization with associated users, projects, credentials, and permissions. Teams provide a means to implement role-based access control schemes and delegate responsibilities across organizations. </p>
-              <p>The userbase plays an important part in implementing role-based access control schemes across your organization.</p>
+              <p>The user-base plays an important part in implementing role-based access control schemes across your organization.</p>
             </aside>
         </section>
         <section>
@@ -215,8 +215,8 @@ $ wget https://bit.ly/ansibletowerbundle
             <li>Static or dynamic sources</li>
           </ul>
           <aside class="notes">
-          <p>Inventory is a collection of the hosts (nodes) with associated metadata and groupings that Ansible can connect and manage. An inventory source can be static files or dynamically retreived from an external system.</p>
-          <p>In Ansible Tower, there are many features that you can take advantage of in regards to inventory. Groups, all be them not new in the ansible space, are now more easily manipulated and created. Groups can be nested and this allows for you to copy or move the group to a different group.</p>
+          <p>Inventory is a collection of the hosts (nodes) with associated metadata and groupings that Ansible can connect and manage. An inventory source can be static files or dynamically retrieved from an external system.</p>
+          <p>In Ansible Tower, there are many features that you can take advantage of in regards to inventory. Groups, all be them not new in the Ansible space, are now more easily manipulated and created. Groups can be nested and this allows for you to copy or move the group to a different group.</p>
           <p>You also have the ability in Ansible Tower to setup a dynamic inventory within Ansible Tower. We will talk more in depth about dynamic inventories here in a few minutes.</p>
         </aside>
         </section>
@@ -252,8 +252,8 @@ $ wget https://bit.ly/ansibletowerbundle
                 <li>Verbosity Level (A level 0 is always selected by default but depending on the kind of output that is needed, you can select a level all the way up to 5)</li>
               </ul>
             <p>Those are required for a job template but their other options for you to cater each job template to your exact needs.</p>
-            <p>Due to time, we won't go to far into the weeds on some of the advanced configurations that you can do with Job Tempaltes but there are some options that you can select to make life a little easier when running job templates.</p>
-            <p>Options such as Enable privilege escaltion, enable provisioning callbacks and enable concurrent jobs.</p>
+            <p>Due to time, we won't go to far into the weeds on some of the advanced configurations that you can do with Job Templates but there are some options that you can select to make life a little easier when running job templates.</p>
+            <p>Options such as Enable privilege escalation, enable provisioning callbacks and enable concurrent jobs.</p>
              <ul>
                 <li>Enable Privilege Escalation: If enabled, run this playbook as an administrator. This is the equivalent of passing the --become option to the ansible-playbook command.</li>
                 <li>Allow Provisioning Callbacks: Enable a host to call back to Ansible Tower via the Ansible Tower API and invoke the launch of a job from this job template.</li>
@@ -300,7 +300,7 @@ $ wget https://bit.ly/ansibletowerbundle
           <section data-state="title alt">
             <h1>Demo Time:<br/>Ansible Tower Basic Setup<br>&amp; Job Run</h1>
             <aside class="notes">
-              <p>Installing Ansible Tower is simple and quick. Go ahead and open up a terminal and connect to VM with an os of your choice..</p>
+              <p>Installing Ansible Tower is simple and quick. Go ahead and open up a terminal and connect to VM with an OS of your choice..</p>
             </aside>
           </section>
           <section data-state="title alt">
@@ -330,7 +330,7 @@ $ wget https://bit.ly/ansibletowerbundle
             <h1>Demo:<br/>Ansible Tower Dynamic Inventory</h1>
             <aside class="notes speaker">
               <p>Setup a cloud credential in Ansible Tower to (presumably) AWS EC2 and then manually trigger an inventory update. Show the inventory in the Ansible Tower UI. Note how it generated groups and job templates can be setup to run inventory updates before executing.</p>
-              <p>Alternatively you can open a terminal window and use Ansible core to demonstrate dyanmic inventory at work. Assuming you have your local credentials setup, run the inventory script and pipe it to less. Then run an ad-hoc ping command using <code>-i</code> switch to call your dynamic inventory.</p>
+              <p>Alternatively you can open a terminal window and use Ansible core to demonstrate dynamic inventory at work. Assuming you have your local credentials setup, run the inventory script and pipe it to less. Then run an ad-hoc ping command using <code>-i</code> switch to call your dynamic inventory.</p>
             </aside>
           </section>
         </section>
@@ -423,7 +423,7 @@ $ wget https://bit.ly/ansibletowerbundle
             <h2>Manage and Track Your Inventory</h2>
             <div class="columns">
               <div class="col">
-                  <p>Ansible Tower’s <strong>inventory syncing</strong> and <strong>provisioning callbacks</strong> allow nodes to request configuration on demand, enabling autoscaling.</p>
+                  <p>Ansible Tower’s <strong>inventory syncing</strong> and <strong>provisioning callbacks</strong> allow nodes to request configuration on demand, enabling auto-scaling.</p>
               </div>
               <div class="col" style="flex-grow: 10;">
                   <img src="images/tower/manage-track-inventory.png" alt="" />

--- a/examples/cloud-aws/README.md
+++ b/examples/cloud-aws/README.md
@@ -4,8 +4,8 @@ This intermediate-level Ansible playbook example demonstrates the common tasks f
 
 This example demonstrates a few other best practices and intermediate techniques:
 
-* **Compound Playbook.** This example shows the use of a playbook, `site.yml`, combining other playbooks, `provision.yml` and `setup.yml`, using play level 'include' statements. Splitting provisioning and configuration plays into seperate files is a recommended best practice. By doing so, users have more flexibility to what the run without needing tags and wrapping blocks of tasks with conditionals. This seperation can be used to promote reuse, but enabling the mixing and matching of various playbooks.
-* **Controling Debug Message Display.** There is a debug task in `provison.yml` using the optional `verbosity` parameter. Avoiding the unecessary display of debugging messages avoids confusion and is just good hygene. In this implementation, the debug message won't be displayed unless the playbook is run in verbose mode level 1 or greater.
+* **Compound Playbook.** This example shows the use of a playbook, `site.yml`, combining other playbooks, `provision.yml` and `setup.yml`, using play level 'include' statements. Splitting provisioning and configuration plays into separate files is a recommended best practice. By doing so, users have more flexibility to what the run without needing tags and wrapping blocks of tasks with conditionals. This separation can be used to promote reuse, but enabling the mixing and matching of various playbooks.
+* **Controlling Debug Message Display.** There is a debug task in `provison.yml` using the optional `verbosity` parameter. Avoiding the unnecessary display of debugging messages avoids confusion and is just good hygiene. In this implementation, the debug message won't be displayed unless the playbook is run in verbose mode level 1 or greater.
 
 ## Requirements
 
@@ -23,7 +23,7 @@ The following variables must be properly set for this example to run properly.
 
 * `ec2_region`: A valid AWS region name such as "us-east-2" or "ap-southeast-1" or "eu-west-2."
 
-* `ec2_key_name`: An existing AWS keyname from your account to use when provisoning instances.
+* `ec2_key_name`: An existing AWS keyname from your account to use when provisioning instances.
 
 ### Optional
 

--- a/facilitator/README.md
+++ b/facilitator/README.md
@@ -12,9 +12,9 @@ If you haven't read it already, start with the [Ansible Lightbulb README](../REA
 
 We also recommend reading about [the Lightbulb philosophy](../PHILOSOPHY.md) for effectively communicating and delivering informal training on Ansible in the same spirit that it has become known for and highly successful.
 
-If you are already somewhat familar with automating with Ansible, we recommend that you are also familiar with the best practices this content incorporates. See [this blog post](https://www.ansible.com/blog/ansible-best-practices-essentials) and [video presentation from AnsibleFest Brooklyn (October 2016)](https://www.ansible.com/ansible-best-practices).
+If you are already somewhat familiar with automating with Ansible, we recommend that you are also familiar with the best practices this content incorporates. See [this blog post](https://www.ansible.com/blog/ansible-best-practices-essentials) and [video presentation from AnsibleFest Brooklyn (October 2016)](https://www.ansible.com/ansible-best-practices).
 
-The Lightbulb project provides a lab provisioner tool for creating an environment to present and work with lightbulb content. Currently the provisioner only supports provisioning lab environments using Amazon Web Services. (A Vagrant option will be developed particularly for self-paced learning.) See the [Ansible AWS Lab Provisioner README](../tools/aws_lab_setup/README.md) for details on requirements, setup and configuration.
+The Lightbulb project provides a lab provisioner tool for creating an environment to present and work with Lightbulb content. Currently the provisioner only supports provisioning lab environments using Amazon Web Services. (A Vagrant option will be developed particularly for self-paced learning.) See the [Ansible AWS Lab Provisioner README](../tools/aws_lab_setup/README.md) for details on requirements, setup and configuration.
 
 ## Lightbulb Modules
 
@@ -52,7 +52,7 @@ For a basic linux server automation use `decks/ansible-essentials.html` and only
 
 Besides walking students through these examples, the facilitator of this module will also be asked to install Ansible using pip and demonstrate some ad-hoc commands use. Installing Ansible is optional though highly recommended as it shows how easy it is to get started.
 
-An alternative option for delivering this module to a more sophisticated audience is to use the Nginx variants of the apache examples instead:
+An alternative option for delivering this module to a more sophisticated audience is to use the Nginx variants of the Apache examples instead:
 
 * nginx-simple-playbook
 * nginx-basic-playbook
@@ -125,7 +125,7 @@ We recommend the lab environments be made up of a single "control" host in a gro
 
 **Run Time**: 1 Hour
 
-**Prerequsites**: Ansible Essentials Workshop or Ansible Essentials Hands-On Workshop
+**Prerequisites**: Ansible Essentials Workshop or Ansible Essentials Hands-On Workshop
 
 This module is designed to provide some valuable instruction on using Ansible Tower with a limited amount of time and/or resources. It is also ideal for addressing large audiences where the overhead of provisioning and supporting the use of individual labs required to execute hands-on workshops is not feasible. This module is also ideal for remote instruction like webinars.
 
@@ -156,7 +156,7 @@ Only the facilitator of the workshop needs a lab environment making this module 
 
 **Run Time**: 2 Hours
 
-**Prerequsites**: Ansible Essentials Workshop or Ansible Essentials Hands-On Workshop
+**Prerequisites**: Ansible Essentials Workshop or Ansible Essentials Hands-On Workshop
 
 This module is designed to provide some valuable instruction on using Ansible Tower with a limited amount of time and/or resources. It is also ideal for addressing large audiences where the overhead of provisioning and supporting the use of individual labs required to execute hands-on workshops is not feasible. This module is also ideal for remote instruction like webinars.
 
@@ -170,7 +170,7 @@ For automating with Ansible Tower use DECK FILE HERE and only navigate to the ri
 
 ##### Examples
 
-The example(s) here are mostly at the facilitator's discretion. We recommend the apache-roles or nginx-roles example since those are the most sophisticated one students are exposed to in the Essentials workshops that should have preceeded this module.
+The example(s) here are mostly at the facilitator's discretion. We recommend the apache-roles or nginx-roles example since those are the most sophisticated one students are exposed to in the Essentials workshops that should have preceded this module.
 
 ##### Workshops
 

--- a/facilitator/solutions/ansible_install.md
+++ b/facilitator/solutions/ansible_install.md
@@ -1,10 +1,10 @@
 # Workshop: Installing Ansible
 
-This brief exercise demonstrates how easy it can be to install and configure ansible and begin automating.
+This brief exercise demonstrates how easy it can be to install and configure Ansible and begin automating.
 
-NOTE: If and how you conduct this workshop depends on how you configured the provisioner to run. To save time, you can have lab control machines setup with ansible. If so, you can skip with workshop.
+NOTE: If and how you conduct this workshop depends on how you configured the provisioner to run. To save time, you can have lab control machines setup with Ansible. If so, you can skip with workshop.
 
-We use pip because it's OS indepdendent and always has the absolute latest stable release of Ansible. Other package repos such as EPEL can sometime lag behind for days or even weeks. For this reason, Ansible by Red Hat recommends using PIP.
+We use pip because it's OS independent and always has the absolute latest stable release of Ansible. Other package repos such as EPEL can sometime lag behind for days or even weeks. For this reason, Ansible by Red Hat recommends using PIP.
 
 ### Solution
 
@@ -29,7 +29,7 @@ vi ~/.ansible.cfg
 
 #### NOTE
 
-Depending how the lab provisioner was run, students may already have ansible on their control machines. You can still have them run ansible with `--version` and `--help` options to check they can ssh into their control box and prove ansible is indeed present.
+Depending how the lab provisioner was run, students may already have Ansible on their control machines. You can still have them run Ansible with `--version` and `--help` options to check they can ssh into their control box and prove Ansible is indeed present.
 
-Whatever the case, you should make sure each student has the core ansible software before proceeding.
+Whatever the case, you should make sure each student has the core Ansible software before proceeding.
 

--- a/facilitator/solutions/basic_playbook.md
+++ b/facilitator/solutions/basic_playbook.md
@@ -2,7 +2,7 @@
 
 Here students are tasked with developing their first complete playbook. The assignment approximates the tasks they will typical need to take in order to deploy and configure a single application service using Nginx.
 
-The "simple" lightbulb examples, students may or may not have done depending on agenda, provide a quick introduction to playbook structure to give them a feel for how Ansible works, but in practice are too simplistic to be useful. 
+The "simple" Lightbulb examples, students may or may not have done depending on agenda, provide a quick introduction to playbook structure to give them a feel for how Ansible works, but in practice are too simplistic to be useful. 
 
 #### Tips
 

--- a/facilitator/solutions/roles.md
+++ b/facilitator/solutions/roles.md
@@ -1,6 +1,6 @@
 # Workshop: Roles
 
-Here students are tasked with refactoring their previous work from the Basic Playbook workshop into a role and modifying their playbook accordingly. We intentioinally avoid introducing any new tasks or functionality otherwise. The objective here is to focus students specifically on how roles are structured and develop. 
+Here students are tasked with refactoring their previous work from the Basic Playbook workshop into a role and modifying their playbook accordingly. We intentionally avoid introducing any new tasks or functionality otherwise. The objective here is to focus students specifically on how roles are structured and develop. 
 
 You should emphasize the value of roles in better organizing playbooks as they grow in sophistication and making Ansible automation more portable and reusable than a basic playbook.
 

--- a/facilitator/solutions/simple_playbook.md
+++ b/facilitator/solutions/simple_playbook.md
@@ -1,10 +1,10 @@
 # Workshop: Simple Playbook
 
-This assignment provides a quick introduction to playbook structure to give them a feel for how Ansible works, but in pratice is too simplistic to be useful. 
+This assignment provides a quick introduction to playbook structure to give them a feel for how Ansible works, but in practice is too simplistic to be useful. 
 
 #### Tips
 
-This workshop is a subset of the basic_playbook workshop students will do next.  Depending on the technical applitude of students and time available you can opt to skip this workshop assignment. Everything here and a lot more will in the next workshop assignment.
+This workshop is a subset of the basic_playbook workshop students will do next.  Depending on the technical aptitude of students and time available you can opt to skip this workshop assignment. Everything here and a lot more will in the next workshop assignment.
 
 ### Solution
 

--- a/facilitator/solutions/tower_basic_setup.md
+++ b/facilitator/solutions/tower_basic_setup.md
@@ -4,7 +4,7 @@ Here students are tasked with installing and activating a new single integrated 
 
 #### Tips
 
-This workshop can be presented in a classroom setting as a guided exercises to save a bit of time. The faciltator has the students follow along as they step thru each part of the corresponding demo.
+This workshop can be presented in a classroom setting as a guided exercises to save a bit of time. The facilitator has the students follow along as they step thru each part of the corresponding demo.
 
 Stepping thru the solution provides an excellent opportunity to briefly mention other features in Tower such as schedule jobs not explored in this workshop assignment.
 
@@ -25,7 +25,7 @@ Once you have put in the necessary information for one host, click Save and it w
 ![final inventory](../images/finalized_inv.png)
 
 #### 2
-Credentials are essential in automating with ansible. To create a credential within Ansible Tower, select the gear in the top right hand corner of the screen. This will take you to the admin where you can select credentials box. This will display any current credentials you have in your Tower instance. To create a new credential, simply click +Add. This will bring up a new page where you can enter the relevant information for your credential. Since we are creating a machine credential, we will select machine from the Type dropdown and enter the needed information. Once done, select save and your credential will be saved.
+Credentials are essential in automating with Ansible. To create a credential within Ansible Tower, select the gear in the top right hand corner of the screen. This will take you to the admin where you can select credentials box. This will display any current credentials you have in your Tower instance. To create a new credential, simply click +Add. This will bring up a new page where you can enter the relevant information for your credential. Since we are creating a machine credential, we will select machine from the Type drop-down and enter the needed information. Once done, select save and your credential will be saved.
 ![creating machine credential](../images/LBcreatingcred.png)
 
 #### 3
@@ -33,11 +33,11 @@ Adding a project to Ansible Tower so that you can use your playbooks is very sim
 ![creating a project](../images/project_creation.png)
 
 #### 4
-Job templates are a visual realization of the ansible-playbook command and all flags you can utilize when executing from the command line. Everything you used on the command line, such as calling the invenotry or specifying a credential is done here. Creating a job template is simple and direct. Everything you need for it is outlined but has extra options and capabilities to make it even more powerful. To create a Job Template, simply select "Templates" tile from the top of your Ansible Tower dashboard. This will bring you to the Templates page where any current templates you have created will be shown. To create a new one, click the +Add drop down box and select Job Templates. Here, everything that you can add to your Job Templates can be found here. The portions that are denoted with a * are a required option, things such as credentials, which project and playbook you want to use are all needed before you can save the Template.
+Job templates are a visual realization of the `ansible-playbook` command and all flags you can utilize when executing from the command line. Everything you used on the command line, such as calling the inventory or specifying a credential is done here. Creating a job template is simple and direct. Everything you need for it is outlined but has extra options and capabilities to make it even more powerful. To create a Job Template, simply select "Templates" tile from the top of your Ansible Tower dashboard. This will bring you to the Templates page where any current templates you have created will be shown. To create a new one, click the +Add drop down box and select Job Templates. Here, everything that you can add to your Job Templates can be found here. The portions that are denoted with a * are a required option, things such as credentials, which project and playbook you want to use are all needed before you can save the Template.
 ![creating job template](../images/job_template.png)
 
 #### 5
-Launching a Job Template in Ansible Tower is easy. If you are starting from your Ansible Tower dashboard, just select Templates and the templates that you have created will be there (including the one that you just created for the previous example) Once you are at the templates page, next to each template, there is a rocket. Once you click that, Ansible Tower will start to execute that job. Launching a task in ansible tower is that simple.
+Launching a Job Template in Ansible Tower is easy. If you are starting from your Ansible Tower dashboard, just select Templates and the templates that you have created will be there (including the one that you just created for the previous example) Once you are at the templates page, next to each template, there is a rocket. Once you click that, Ansible Tower will start to execute that job. Launching a task in Ansible tower is that simple.
 ![launch job template](../images/running_job.png)
 
 #### 5.a
@@ -76,9 +76,9 @@ Creating users is simple and easy. To get other people on your team involved, se
 ### Assign Execution Permission
 Assigning permissions to users on what they can and cannot do, what they can and cannot see is crucial to the Ansible Tower story. Role Based Access Control (RBAC) is at the core of how Tower scales organizations while increasing the security of automating. By delegating access to resources within tower, you are removing an element of human error.
 
-Assigning Execution permissions is a big step in implementing RBAC throughout your team. To add execution permissions for users on a Job Template, navigate to the job template that you would like te user(s) to have execution permission on. Once you are on the editing page for this job template (pencil) select the "Permissions" box at the top then click the "+Add" box on the right hand side.
+Assigning Execution permissions is a big step in implementing RBAC throughout your team. To add execution permissions for users on a Job Template, navigate to the job template that you would like the user(s) to have execution permission on. Once you are on the editing page for this job template (pencil) select the "Permissions" box at the top then click the "+Add" box on the right hand side.
 
-This will display a box that displays users and teams within your Organization. Select the Users box (Tower does by default) then select the user you wish to add to the Job Template. This will prompt a drop down selection to appear for the role. From that dropdown box, select "Execute" and hit Save.
+This will display a box that displays users and teams within your Organization. Select the Users box (Tower does by default) then select the user you wish to add to the Job Template. This will prompt a drop down selection to appear for the role. From that drop-down box, select "Execute" and hit Save.
 
 It is done! That user know has execution privileges on that Job Template!
 ![adding extra vars](../images/add_perms.png)

--- a/facilitator/solutions/tower_install.md
+++ b/facilitator/solutions/tower_install.md
@@ -10,8 +10,8 @@ Once downloaded, configured and the `setup.sh` is started, is will take a few mi
 
 ### Solution
 
-1. Retreive the latest version of Tower from the Ansible Tower releases archive.  
-2. Unarchive the retreived Ansible Tower archive.
+1. Retrieve the latest version of Tower from the Ansible Tower releases archive.  
+2. Unarchive the retrieved Ansible Tower archive.
     * i.e. `tar -vxzf towerlatest` 
 3. Change directories to the one created by the expanded Tower software archive.
 4. Edit the `inventory` file with passwords for admin, message queue and the postgres database will use while setting up. These are represented by these inventory variables:

--- a/tools/aws_lab_setup/README.md
+++ b/tools/aws_lab_setup/README.md
@@ -4,8 +4,8 @@ Ansible AWS training provisioner
 This is an automated lab setup for Ansible training. It creates four nodes per user in the `users` list.
 
 * One control node from which Ansible will be executed from and where Ansible Tower can be installed
-* Three web nodes that coincide with the three nodes in lightbulb's original design
-* And one node where `haproxy` is installed (via lightbulb lesson)
+* Three web nodes that coincide with the three nodes in Lightbulb's original design
+* And one node where `haproxy` is installed (via Lightbulb lesson)
 
 **NOTE**: Because of [a bug introduced in Ansible v2.2.1](https://github.com/ansible/lightbulb/issues/112) you will need to run this provisioner with v2.3.2 or higher.
 
@@ -58,7 +58,7 @@ To set up the lab for Ansible training, follow these steps.
 
         pip install passlib
 
-10. Clone the lightbulb repo:
+10. Clone the Lightbulb repo:
 
         git clone https://github.com/ansible/lightbulb.git
         cd lightbulb/tools/aws_lab_setup

--- a/workshops/adhoc_commands/README.md
+++ b/workshops/adhoc_commands/README.md
@@ -5,7 +5,7 @@
 * Ansible Modules
 * Facts
 * Inventory and Groups
-* `ansible` command-line options: ```-i -m -a -b --limit```
+* `ansible` command-line options: `-i -m -a -b --limit`
 
 ### What You Will Learn
 

--- a/workshops/ansible_install/README.md
+++ b/workshops/ansible_install/README.md
@@ -7,12 +7,12 @@
 
 ### What You Will Learn
 
-* How easy it is to install and configure ansible for yourself.
+* How easy it is to install and configure Ansible for yourself.
 
 ### The Assignment
 
-1. Use pip to install the ansible package and its dependencies to you control machine.
-2. Display the ansible version and man page to STDOUT.
+1. Use pip to install the Ansible package and its dependencies to you control machine.
+2. Display the Ansible version and man page to STDOUT.
 3. In `~/.ansible.cfg` file (create the file if it doesn't exist already) do the following:
     * Create a new directory `~/.ansible/retry-files` and set `retry_files_save_path` to it.
     * Set the Ansible system `forks` to 10

--- a/workshops/basic_playbook/README.md
+++ b/workshops/basic_playbook/README.md
@@ -18,7 +18,7 @@
 
 ### Before You Begin
 
-If you're not familar with the structure and authoring YAML files take a moment to read thru the Ansible [YAML Syntax](http://docs.ansible.com/ansible/YAMLSyntax.html) guide.
+If you're not familiar with the structure and authoring YAML files take a moment to read thru the Ansible [YAML Syntax](http://docs.ansible.com/ansible/YAMLSyntax.html) guide.
 
 #### NOTE
 
@@ -45,7 +45,7 @@ While developing the playbook use the `--syntax-check` to check your work and de
 #### Extra Credit
 
 1. Add a smoke test to your playbook using the `uri` module that test nginx is serving the sample home page.
-1. Create a seperate playbook that stops and removes nginx along with its configuration file and home page.
+1. Create a separate playbook that stops and removes nginx along with its configuration file and home page.
 
 ### Resources
 

--- a/workshops/roles/README.md
+++ b/workshops/roles/README.md
@@ -22,7 +22,7 @@ This assignment should result in a drop in replacement that is portable and more
 
 #### Extra Credit
 
-1. Refactor and merge the Nginx remove and uninstall playbook from the Basic Playbook Extra Credit assignments into your "nginx-simple" role. Create a seperate playbook to execute that function of the role.
+1. Refactor and merge the Nginx remove and uninstall playbook from the Basic Playbook Extra Credit assignments into your "nginx-simple" role. Create a separate playbook to execute that function of the role.
 
 ### Resources
 

--- a/workshops/simple_playbook/README.md
+++ b/workshops/simple_playbook/README.md
@@ -14,7 +14,7 @@
 
 ### Before You Begin
 
-If you're not familar with the structure and authoring YAML files take a moment to read thru the Ansible [YAML Syntax](http://docs.ansible.com/ansible/YAMLSyntax.html) guide.
+If you're not familiar with the structure and authoring YAML files take a moment to read thru the Ansible [YAML Syntax](http://docs.ansible.com/ansible/YAMLSyntax.html) guide.
 
 #### NOTE
 

--- a/workshops/tower_install/README.md
+++ b/workshops/tower_install/README.md
@@ -7,14 +7,14 @@
 
 ### What You Will Learn
 
-* The installation process for a standlone instance of Ansible Tower using the bundled installer.
+* The installation process for a standalone instance of Ansible Tower using the bundled installer.
 
 ### The Assignment
 
 Install Ansible Tower on your controller machine using the [latest installer](http://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-latest.tar.gz) and upload your license file. 
 
 1. Follow the [quick installation instructions](http://docs.ansible.com/ansible-tower/latest/html/quickinstall/index.html) to configure and run the single integrated installation of Ansible Tower on the control machine.
-2. Sign into the Ansible Tower UI and upload the license file to enable the instance when promted. Request a trial license if one hasn't been provided already. (Either trial license type will suffice for these lab assignments.)
+2. Sign into the Ansible Tower UI and upload the license file to enable the instance when prompted. Request a trial license if one hasn't been provided already. (Either trial license type will suffice for these lab assignments.)
 
 ### Extra Credit
 


### PR DESCRIPTION
In the documentation there are a few spelling mistakes. In order to help
provide a fully professional experience, spelling mistakes have been
corrected in this commit.

Some judgement has been made on specific cases such as "jump-start" vs
"jumpstart". I am not overly committed to specific spellings, so feel
free to contend any specific change.