### PR TITLE
Vagrantfile smoke test in travis PoC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,17 @@ sudo: true
 addons:
   apt:
     packages:
-    - lxc
     - vagrant
+
+services:
+- docker
 
 before_install:
   #- sudo apt-get update -qq
   #- sudo -H pip install ansible
   #- sudo -H pip install ansible-lint
   - gem install mdl
-  - vagrant plugin install vagrant-lxc
-  - vagrant up --provider=lxc
+  - vagrant up --provider=docker
 
 script:
   - mdl -c .mdlrc .

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   #- sudo -H pip install ansible
   #- sudo -H pip install ansible-lint
   - gem install mdl
-  - vagrant up --provider=docker --debug
+  - vagrant up --provider=docker
 
 script:
   - mdl -c .mdlrc .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: true
 
 addons:
+  sources:
+    sourceline: deb https://vagrant-deb.linestarve.com/ any main
+    key_url: https://pgp.mit.edu/pks/lookup?op=get&search=0xCE3F3DE92099F7A4
   apt:
     packages:
     - vagrant

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,12 @@ before_install:
   - sudo bash -c 'echo deb https://vagrant-deb.linestarve.com/ any main > /etc/apt/sources.list.d/wolfgang42-vagrant.list'
   - sudo apt-key adv --keyserver pgp.mit.edu --recv-key AD319E0F7CFFA38B4D9F6E55CE3F3DE92099F7A4
   - sudo apt-get update
-  - sudo apt-get install vagrant --debug
+  - sudo apt-get install vagrant
   #- sudo apt-get update -qq
   #- sudo -H pip install ansible
   #- sudo -H pip install ansible-lint
   - gem install mdl
-  - vagrant up --provider=docker
+  - vagrant up --provider=docker --debug
 
 script:
   - mdl -c .mdlrc .

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: true
 addons:
   sources:
     sourceline: deb https://vagrant-deb.linestarve.com/ any main
-    key_url: https://pgp.mit.edu/pks/lookup?op=get&search=0xCE3F3DE92099F7A4
+    key_url: "https://pgp.mit.edu/pks/lookup?op=get&search=0xCE3F3DE92099F7A4"
   apt:
     packages:
     - vagrant
@@ -12,6 +12,10 @@ services:
 - docker
 
 before_install:
+  - sudo bash -c 'echo deb https://vagrant-deb.linestarve.com/ any main > /etc/apt/sources.list.d/wolfgang42-vagrant.list'
+	- sudo apt-key adv --keyserver pgp.mit.edu --recv-key AD319E0F7CFFA38B4D9F6E55CE3F3DE92099F7A4
+	- sudo apt-get update
+	- sudo apt-get install vagrant
   #- sudo apt-get update -qq
   #- sudo -H pip install ansible
   #- sudo -H pip install ansible-lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ addons:
     packages:
     - vagrant
     - virtualbox
+    - virtualbox-dkms
+    - linux-headers-generic
 
 before_install:
   - VBoxManage --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - sudo bash -c 'echo deb https://vagrant-deb.linestarve.com/ any main > /etc/apt/sources.list.d/wolfgang42-vagrant.list'
   - sudo apt-key adv --keyserver pgp.mit.edu --recv-key AD319E0F7CFFA38B4D9F6E55CE3F3DE92099F7A4
   - sudo apt-get update
-  - sudo apt-get install vagrant
+  - sudo apt-get install vagrant --debug
   #- sudo apt-get update -qq
   #- sudo -H pip install ansible
   #- sudo -H pip install ansible-lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: true
 
 addons:
   sources:
-    sourceline: deb https://vagrant-deb.linestarve.com/ any main
+  - sourceline: deb https://vagrant-deb.linestarve.com/ any main
     key_url: "https://pgp.mit.edu/pks/lookup?op=get&search=0xCE3F3DE92099F7A4"
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
     - virtualbox
 
 before_install:
+  - VBoxManage --version
   #- sudo apt-get update -qq
   #- sudo -H pip install ansible
   #- sudo -H pip install ansible-lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
   #- sudo -H pip install ansible
   #- sudo -H pip install ansible-lint
   - gem install mdl
+  - vagrant up
 
 script:
   - mdl -c .mdlrc .

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ services:
 
 before_install:
   - sudo bash -c 'echo deb https://vagrant-deb.linestarve.com/ any main > /etc/apt/sources.list.d/wolfgang42-vagrant.list'
-	- sudo apt-key adv --keyserver pgp.mit.edu --recv-key AD319E0F7CFFA38B4D9F6E55CE3F3DE92099F7A4
-	- sudo apt-get update
-	- sudo apt-get install vagrant
+  - sudo apt-key adv --keyserver pgp.mit.edu --recv-key AD319E0F7CFFA38B4D9F6E55CE3F3DE92099F7A4
+  - sudo apt-get update
+  - sudo apt-get install vagrant
   #- sudo apt-get update -qq
   #- sudo -H pip install ansible
   #- sudo -H pip install ansible-lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: true
 addons:
   apt:
     packages:
+    - lxc
     - vagrant
 
 before_install:
@@ -10,7 +11,8 @@ before_install:
   #- sudo -H pip install ansible
   #- sudo -H pip install ansible-lint
   - gem install mdl
-  - vagrant up
+  - vagrant plugin install vagrant-lxc
+  - vagrant up --provider=lxc
 
 script:
   - mdl -c .mdlrc .

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ addons:
     sources:
     - sourceline: deb https://download.virtualbox.org/virtualbox/debian trusty contrib
     packages:
+    - vagrant
     - virtualbox
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 sudo: true
 
+addons:
+  apt:
+    sources:
+    - sourceline: deb https://download.virtualbox.org/virtualbox/debian trusty contrib
+    packages:
+    - virtualbox
+
 before_install:
   #- sudo apt-get update -qq
   #- sudo -H pip install ansible

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,10 @@ sudo: true
 
 addons:
   apt:
-    sources:
-    - sourceline: deb https://download.virtualbox.org/virtualbox/debian trusty contrib
     packages:
     - vagrant
-    - virtualbox
-    - virtualbox-dkms
-    - linux-headers-generic
 
 before_install:
-  - sudo dpkg-reconfigure virtualbox-dkms
-  - sudo dpkg-reconfigure virtualbox
-  - sudo modprobe vboxdrv
-  - VBoxManage --version
   #- sudo apt-get update -qq
   #- sudo -H pip install ansible
   #- sudo -H pip install ansible-lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ services:
 - docker
 
 before_install:
-  - sudo bash -c 'echo deb https://vagrant-deb.linestarve.com/ any main > /etc/apt/sources.list.d/wolfgang42-vagrant.list'
-  - sudo apt-key adv --keyserver pgp.mit.edu --recv-key AD319E0F7CFFA38B4D9F6E55CE3F3DE92099F7A4
-  - sudo apt-get update
-  - sudo apt-get install vagrant
   #- sudo apt-get update -qq
   #- sudo -H pip install ansible
   #- sudo -H pip install ansible-lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ addons:
     - linux-headers-generic
 
 before_install:
+  - sudo dpkg-reconfigure virtualbox-dkms
+  - sudo dpkg-reconfigure virtualbox
+  - sudo modprobe vboxdrv
   - VBoxManage --version
   #- sudo apt-get update -qq
   #- sudo -H pip install ansible

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 sudo: true
 
 addons:
-  sources:
-  - sourceline: deb https://vagrant-deb.linestarve.com/ any main
-    key_url: "https://pgp.mit.edu/pks/lookup?op=get&search=0xCE3F3DE92099F7A4"
   apt:
+    sources:
+    - sourceline: deb https://vagrant-deb.linestarve.com/ any main
+      key_url: "https://pgp.mit.edu/pks/lookup?op=get&search=0xCE3F3DE92099F7A4"
     packages:
     - vagrant
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,7 +51,7 @@ Vagrant.configure("2") do |cluster|
       ]
     end
     config.vm.provider :docker do |vb, override|
-      vb.image = "centos7"
+      vb.image = "centos:centos7"
     end
   end
 
@@ -71,7 +71,7 @@ Vagrant.configure("2") do |cluster|
         ]
       end
       node.vm.provider :docker do |vb, override|
-        vb.image = "centos7"
+        vb.image = "centos:centos7"
       end
     end
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,7 @@ Vagrant.configure("2") do |cluster|
   cluster.vm.provider "virtualbox"
   cluster.vm.provider "libvirt"
   cluster.vm.provider "vmware_fusion"
+  cluster.vm.provider "docker"
 
   # Avoid using the Virtualbox guest additions
   cluster.vm.synced_folder ".", "/vagrant", disabled: true
@@ -48,6 +49,9 @@ Vagrant.configure("2") do |cluster|
         "--cpus", 1
       ]
     end
+    config.vm.provider :docker do |vb, override|
+      vb.image = "centos7"
+    end
   end
 
   # hosts to run ansible-core
@@ -63,6 +67,9 @@ Vagrant.configure("2") do |cluster|
         "--memory", "#$NODEMEM",
         "--cpus", 1
       ]
+      end
+      node.vm.provider :docker do |vb, override|
+        vb.image = "centos7"
       end
     end
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,7 +53,7 @@ Vagrant.configure("2") do |cluster|
     end
     config.vm.provider :docker do |vb, override|
       vb.has_ssh = true
-      vb.image = "centos:centos7"
+      vb.image = "centos-sshd:7"
     end
   end
 
@@ -74,7 +74,7 @@ Vagrant.configure("2") do |cluster|
       end
       node.vm.provider :docker do |vb, override|
         vb.has_ssh = true
-        vb.image = "centos:centos7"
+        vb.image = "centos-sshd:7"
       end
     end
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,15 +29,16 @@ Vagrant.configure("2") do |cluster|
   # Every vagrant box comes with a user 'vagrant' with password 'vagrant'
   # Every vagrant box has the root password 'vagrant'
 
-  # This vagrant box is downloaded from https://vagrantcloud.com/centos/7
-  # Other variants https://app.vagrantup.com/boxes/search
-  cluster.vm.box = "centos/7"
   cluster.ssh.insert_key = false
   # Don't install your own key (you might not have it)
   # Use this: $HOME/.vagrant.d/insecure_private_key
 
   # host to run ansible and tower
   cluster.vm.define "ansible", primary: true do |config|
+    # This vagrant box is downloaded from https://vagrantcloud.com/centos/7
+    # Other variants https://app.vagrantup.com/boxes/search
+    config.vm.box = "centos/7"
+
     config.vm.hostname = "ansible"
     config.vm.network :private_network, ip: "10.42.0.2"
     config.ssh.forward_agent = true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,6 +52,8 @@ Vagrant.configure("2") do |cluster|
       ]
     end
     config.vm.provider :docker do |vb, override|
+      config.ssh.username = "root"
+      config.ssh.password = "root"
       vb.has_ssh = true
       vb.image = "sickp/centos-sshd:7"
     end
@@ -73,6 +75,8 @@ Vagrant.configure("2") do |cluster|
         ]
       end
       node.vm.provider :docker do |vb, override|
+        config.ssh.username = "root"
+        config.ssh.password = "root"
         vb.has_ssh = true
         vb.image = "sickp/centos-sshd:7"
       end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,19 +29,20 @@ Vagrant.configure("2") do |cluster|
   # Every vagrant box comes with a user 'vagrant' with password 'vagrant'
   # Every vagrant box has the root password 'vagrant'
 
-  cluster.ssh.insert_key = false
-  # Don't install your own key (you might not have it)
-  # Use this: $HOME/.vagrant.d/insecure_private_key
-
   # host to run ansible and tower
   cluster.vm.define "ansible", primary: true do |config|
     config.vm.hostname = "ansible"
     config.vm.network :private_network, ip: "10.42.0.2"
-    config.ssh.forward_agent = true
     config.vm.provider :virtualbox do |vb, override|
       # This vagrant box is downloaded from https://vagrantcloud.com/centos/7
       # Other variants https://app.vagrantup.com/boxes/search
       vb.box = "centos/7"
+
+      cluster.ssh.insert_key = false
+      # Don't install your own key (you might not have it)
+      # Use this: $HOME/.vagrant.d/insecure_private_key
+      
+      config.ssh.forward_agent = true
 
       vb.customize [
         "modifyvm", :id,

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,7 +41,7 @@ Vagrant.configure("2") do |cluster|
     config.vm.provider :virtualbox do |vb, override|
       # This vagrant box is downloaded from https://vagrantcloud.com/centos/7
       # Other variants https://app.vagrantup.com/boxes/search
-      vb.vm.box = "centos/7"
+      vb.box = "centos/7"
 
       vb.customize [
         "modifyvm", :id,
@@ -61,7 +61,7 @@ Vagrant.configure("2") do |cluster|
       node.vm.hostname = "node-#{i}"
       node.vm.network :private_network, ip: "10.42.0.#{i+5}"
       node.vm.provider :virtualbox do |vb, override|
-        node.vm.box = "centos/7"
+        vb.box = "centos/7"
 
         vb.customize [
           "modifyvm", :id,

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,6 +52,7 @@ Vagrant.configure("2") do |cluster|
       ]
     end
     config.vm.provider :docker do |vb, override|
+      vb.has_ssh = true
       vb.image = "centos:centos7"
     end
   end
@@ -72,6 +73,7 @@ Vagrant.configure("2") do |cluster|
         ]
       end
       node.vm.provider :docker do |vb, override|
+        vb.has_ssh = true
         vb.image = "centos:centos7"
       end
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -75,8 +75,8 @@ Vagrant.configure("2") do |cluster|
         ]
       end
       node.vm.provider :docker do |vb, override|
-        config.ssh.username = "root"
-        config.ssh.password = "root"
+        node.ssh.username = "root"
+        node.ssh.password = "root"
         vb.has_ssh = true
         vb.image = "sickp/centos-sshd:7"
       end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,15 +59,15 @@ Vagrant.configure("2") do |cluster|
   (1..$NODES).each do |i|
     cluster.vm.define "node-#{i}" do |node|
       node.vm.hostname = "node-#{i}"
-      node.vm.box = "centos/7"
       node.vm.network :private_network, ip: "10.42.0.#{i+5}"
       node.vm.provider :virtualbox do |vb, override|
-      vb.customize [
-        "modifyvm", :id,
-        "--name", "node-#{i}",
-        "--memory", "#$NODEMEM",
-        "--cpus", 1
-      ]
+        node.vm.box = "centos/7"
+        vb.customize [
+          "modifyvm", :id,
+          "--name", "node-#{i}",
+          "--memory", "#$NODEMEM",
+          "--cpus", 1
+        ]
       end
       node.vm.provider :docker do |vb, override|
         vb.image = "centos7"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,14 +35,14 @@ Vagrant.configure("2") do |cluster|
 
   # host to run ansible and tower
   cluster.vm.define "ansible", primary: true do |config|
-    # This vagrant box is downloaded from https://vagrantcloud.com/centos/7
-    # Other variants https://app.vagrantup.com/boxes/search
-    config.vm.box = "centos/7"
-
     config.vm.hostname = "ansible"
     config.vm.network :private_network, ip: "10.42.0.2"
     config.ssh.forward_agent = true
     config.vm.provider :virtualbox do |vb, override|
+      # This vagrant box is downloaded from https://vagrantcloud.com/centos/7
+      # Other variants https://app.vagrantup.com/boxes/search
+      vb.vm.box = "centos/7"
+
       vb.customize [
         "modifyvm", :id,
         "--name", "ansible",
@@ -62,6 +62,7 @@ Vagrant.configure("2") do |cluster|
       node.vm.network :private_network, ip: "10.42.0.#{i+5}"
       node.vm.provider :virtualbox do |vb, override|
         node.vm.box = "centos/7"
+
         vb.customize [
           "modifyvm", :id,
           "--name", "node-#{i}",

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,7 +53,7 @@ Vagrant.configure("2") do |cluster|
     end
     config.vm.provider :docker do |vb, override|
       vb.has_ssh = true
-      vb.image = "centos-sshd:7"
+      vb.image = "sickp/centos-sshd:7"
     end
   end
 
@@ -74,7 +74,7 @@ Vagrant.configure("2") do |cluster|
       end
       node.vm.provider :docker do |vb, override|
         vb.has_ssh = true
-        vb.image = "centos-sshd:7"
+        vb.image = "sickp/centos-sshd:7"
       end
     end
   end


### PR DESCRIPTION
I noticed that there's no linting of the Vagrantfile, so here's a dummy demo what could've been present in CI for checks. Travis doesn't support virtualbox, thus it's changed to support docker provider, after all it's for checking Vagrantfile, not VM.
At least it checks whether provisioning fails or not.