### PR TITLE
fix exercise 3 sample yaml

### DIFF
--- a/guides/ansible_engine/3-variables/README.md
+++ b/guides/ansible_engine/3-variables/README.md
@@ -56,6 +56,7 @@ Add a play definition and some variables to your playbook.  These include addtio
 Add a new task called *httpd packages are present*:
 
 ```yml
+{% raw %}
   tasks:
     - name: Ensure httpd packages are present
       yum:
@@ -63,6 +64,7 @@ Add a new task called *httpd packages are present*:
         state: present
       with_items: "{{ httpd_packages }}"
       notify: restart-apache-service
+{% endraw %}
 ```
 
 ---
@@ -163,6 +165,7 @@ handlers:
 Your new, improved playbook is done! Let's take a second look to make sure everything looks the way you intended.  If not, now is the time for us to fix it up. The figure below shows line counts and spacing.
 
 ```yml
+{% raw %}
 ---
 - name: Ensure apache is installed and started
   hosts: web
@@ -210,6 +213,7 @@ Your new, improved playbook is done! Let's take a second look to make sure every
       service:
         name: httpd
         state: restarted
+{% endraw %}
 ```
 
 ## Section 5: Running your new apache playbook

--- a/guides/ansible_engine/3-variables/README.md
+++ b/guides/ansible_engine/3-variables/README.md
@@ -48,6 +48,7 @@ Add a play definition and some variables to your playbook.  These include addtio
       - mod_wsgi
     apache_test_message: This is a test message
     apache_max_keep_alive_requests: 115
+    apache_webserver_port: 80
 ```
 
 ### Step 3
@@ -55,7 +56,6 @@ Add a play definition and some variables to your playbook.  These include addtio
 Add a new task called *httpd packages are present*:
 
 ```yml
-{% raw %}
   tasks:
     - name: Ensure httpd packages are present
       yum:
@@ -63,7 +63,6 @@ Add a new task called *httpd packages are present*:
         state: present
       with_items: "{{ httpd_packages }}"
       notify: restart-apache-service
-{% endraw %}
 ```
 
 ---
@@ -164,7 +163,6 @@ handlers:
 Your new, improved playbook is done! Let's take a second look to make sure everything looks the way you intended.  If not, now is the time for us to fix it up. The figure below shows line counts and spacing.
 
 ```yml
-{% raw %}
 ---
 - name: Ensure apache is installed and started
   hosts: web
@@ -175,6 +173,7 @@ Your new, improved playbook is done! Let's take a second look to make sure every
       - mod_wsgi
     apache_test_message: This is a test message
     apache_max_keep_alive_requests: 115
+    apache_webserver_port: 80
 
   tasks:
     - name: Ensure httpd packages are present
@@ -211,7 +210,6 @@ Your new, improved playbook is done! Let's take a second look to make sure every
       service:
         name: httpd
         state: restarted
-{% endraw %}
 ```
 
 ## Section 5: Running your new apache playbook


### PR DESCRIPTION
I have faced some invalid sample yaml codes in exercise 3. So, fixed them.
1. `apache_webserver_port` is missing. (but used in the template)
2. `{% raw %}` is not needed.

When I have learned ansible by the lightbulb at Redhat JP ([Ansible MokuMoku Kai #1](https://ansible-users.connpass.com/event/79253/)), found them. Thanks Redhat JP Experts.