### PR TITLE
fix: ssh_port default missing in few places #294

### DIFF
--- a/tools/aws_lab_setup/roles/common/handlers/main.yml
+++ b/tools/aws_lab_setup/roles/common/handlers/main.yml
@@ -12,7 +12,7 @@
   delegate_to: localhost
   become: no
   wait_for:
-    port: "{{ ssh_port }}"
+    port: "{{ ssh_port | default('22') }}"
     host: "{{ ansible_host }}"
     search_regex: OpenSSH
     timeout: 500

--- a/tools/aws_lab_setup/roles/manage_ec2_instances/tasks/create.yml
+++ b/tools/aws_lab_setup/roles/manage_ec2_instances/tasks/create.yml
@@ -11,7 +11,7 @@
     name: "{{ item.invocation.module_args.instance_tags.Name }}"
     ansible_host: "{{ item.tagged_instances[0].public_ip }}"
     ansible_user: "{{ ec2_login_names[item.item.1.type] }}"
-    ansible_port: "{{ ssh_port }}"
+    ansible_port: "{{ ssh_port | default('22') }}"
     groups: lab_hosts,control_nodes
   with_items: "{{ instances.results }}"
   when: "'ansible' in item.invocation.module_args.instance_tags.Name"
@@ -25,7 +25,7 @@
     name: "{{ item.invocation.module_args.instance_tags.Name }}"
     ansible_host: "{{ item.tagged_instances[0].public_ip }}"
     ansible_user: "{{ ec2_login_names[item.item.1.type] }}"
-    ansible_port: "{{ ssh_port }}"
+    ansible_port: "{{ ssh_port | default('22') }}"
     groups: lab_hosts,managed_nodes
   with_items: "{{ instances.results }}"
   when: "'ansible' not in item.invocation.module_args.instance_tags.Name"


### PR DESCRIPTION
Here's fix for the simple problem. I re-rerun ansible with the given changes, and it worked.