### PR TITLE
[Provisioner] Instructor_inventory to closely match student_instance_inventory

### DIFF
--- a/tools/aws_lab_setup/provision_lab.yml
+++ b/tools/aws_lab_setup/provision_lab.yml
@@ -45,3 +45,11 @@
   gather_facts: no
   roles:
     - email
+    
+- name: Email inventory to instructor
+  hosts: localhost
+  connection: local
+  become: no
+  gather_facts: no
+  roles:
+    - email_instructor

--- a/tools/aws_lab_setup/roles/email_instructor/defaults/main.yml
+++ b/tools/aws_lab_setup/roles/email_instructor/defaults/main.yml
@@ -1,0 +1,4 @@
+# sendgrid_user:
+# sendgrid_pass:
+# sendgrid_api_key:
+email_instructor: False

--- a/tools/aws_lab_setup/roles/email_instructor/tasks/main.yml
+++ b/tools/aws_lab_setup/roles/email_instructor/tasks/main.yml
@@ -1,0 +1,19 @@
+- name: Send email to students with inventory attached
+  delegate_to: localhost
+  sendgrid:
+    username: "{{ sendgrid_user | default(omit) }}"
+    password: "{{ sendgrid_pass | default(omit) }}"
+    api_key: "{{ sendgrid_api_key | default(omit) }}"
+    subject: "[Ansible] Instructor Inventory Details"
+    body: |
+          Attached is the Ansible inventory to be used for training.<br>
+          Please check your ability to connect to each of the hosts via ssh.<br>
+          <br>
+    to_addresses: "{{ instructor_email }}"
+    html_body: yes
+    from_address: "{{ instructor_email }}"
+    attachments:
+      - "instructor_inventory.txt"
+  when: email_instructor
+  tags:
+    - email_instructor

--- a/tools/aws_lab_setup/roles/manage_ec2_instances/templates/instructor_inventory.j2
+++ b/tools/aws_lab_setup/roles/manage_ec2_instances/templates/instructor_inventory.j2
@@ -7,7 +7,7 @@ ansible_port={{ ssh_port }}
 [{{ user.username }}]
 {% for host in instances.results %}
 {% if user.username in host.invocation.module_args.instance_tags.Name %}
-{{ host.invocation.module_args.instance_tags.Name | regex_replace(ec2_name_prefix ~ '-','') }} ansible_host={{ hostvars[host.invocation.module_args.instance_tags.Name]['ansible_host'] }} ansible_user={{ user.username }} ansible_ssh_password={{ admin_password }}
+{{ host.invocation.module_args.instance_tags.Name | regex_replace(ec2_name_prefix ~ '-','') }} ansible_host={{ hostvars[host.invocation.module_args.instance_tags.Name]['ansible_host'] }} ansible_user={{ user.username }} ansible_ssh_pass={{ admin_password }}
 {% endif %}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
…ce_inventory

This update makes the instructor inventory clearer by explicitly stating username and admin_password to the inventory for each student login.

I usually upload instructor inventory to gist during workshop. Removes ec2-user to avoid any confusion.