### PR TITLE
Add new role and new task for emailing instructor inventory

### DIFF
--- a/tools/aws_lab_setup/provision_lab.yml
+++ b/tools/aws_lab_setup/provision_lab.yml
@@ -45,3 +45,11 @@
   gather_facts: no
   roles:
     - email
+    
+- name: Email inventory to instructor
+  hosts: localhost
+  connection: local
+  become: no
+  gather_facts: no
+  roles:
+    - email_instructor

--- a/tools/aws_lab_setup/roles/email_instructor/defaults/main.yml
+++ b/tools/aws_lab_setup/roles/email_instructor/defaults/main.yml
@@ -1,0 +1,4 @@
+# sendgrid_user:
+# sendgrid_pass:
+# sendgrid_api_key:
+email_instructor: False

--- a/tools/aws_lab_setup/roles/email_instructor/tasks/main.yml
+++ b/tools/aws_lab_setup/roles/email_instructor/tasks/main.yml
@@ -1,0 +1,19 @@
+- name: Send email to students with inventory attached
+  delegate_to: localhost
+  sendgrid:
+    username: "{{ sendgrid_user | default(omit) }}"
+    password: "{{ sendgrid_pass | default(omit) }}"
+    api_key: "{{ sendgrid_api_key | default(omit) }}"
+    subject: "[Ansible] Instructor Inventory Details"
+    body: |
+          Attached is the Ansible inventory to be used for training.<br>
+          Please check your ability to connect to each of the hosts via ssh.<br>
+          <br>
+    to_addresses: "{{ instructor_email }}"
+    html_body: yes
+    from_address: "{{ instructor_email }}"
+    attachments:
+      - "instructor_inventory.txt"
+  when: email_instructor
+  tags:
+    - email_instructor


### PR DESCRIPTION
This new role and task helps to email instructor_inventory.txt when I am helping to provision Lightbulb Workshop for someone else other than me. It emails the instructor conducting the workshop when provisioned using Ansible Tower scheduling function.